### PR TITLE
Add support for different JaCoCo report formats

### DIFF
--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AnalysisMojo.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AnalysisMojo.java
@@ -70,7 +70,7 @@ public class AnalysisMojo extends AbstractMeringueMojo {
      * The output formats of JaCoCo report. Available values are {@code XML}, {@code HTML}, and {@code CSV}.
      * By default, the format is set to {@code HTML,CSV,XML}.
      */
-    @Parameter(property = "meringue.outputFormat", defaultValue = "HTML,CSV,XML")
+    @Parameter(property = "meringue.outputJaCoCoFormat", defaultValue = "HTML,CSV,XML")
     private List<ReportFormat> formats;
 
     @Component

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AnalysisMojo.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AnalysisMojo.java
@@ -106,6 +106,8 @@ public class AnalysisMojo extends AbstractMeringueMojo {
             File htmlReportDir = new File(getOutputDir(), "jacoco-report");
             getLog().info("Writing JaCoCo report to: " + htmlReportDir);
             report.writeHtmlReport(getTestDescription(), htmlReportDir);
+            report.writeCsvReport(getTestDescription(), htmlReportDir);
+            report.writeXmlReport(getTestDescription(), htmlReportDir);
         } catch (IOException | ReflectiveOperationException e) {
             throw new MojoExecutionException("Failed to analyze fuzzing campaign", e);
         }

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AnalysisMojo.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AnalysisMojo.java
@@ -66,6 +66,13 @@ public class AnalysisMojo extends AbstractMeringueMojo {
      */
     @Parameter(property = "meringue.timeout", defaultValue = "600")
     private long timeout;
+    /**
+     * The output formats of JaCoCo report. Available values are {@code XML}, {@code HTML}, and {@code CSV}.
+     * By default, the format is set to {@code HTML,CSV,XML}.
+     */
+    @Parameter(property = "meringue.outputFormat", defaultValue = "HTML,CSV,XML")
+    private List<ReportFormat> formats;
+
     @Component
     private ArtifactResolver artifactResolver;
     @Component
@@ -103,11 +110,12 @@ public class AnalysisMojo extends AbstractMeringueMojo {
             getLog().info("Writing coverage report to: " + coverageReportFile);
             getLog().info("Writing failures report to: " + failuresReportFile);
             report.write(coverageReportFile, failuresReportFile);
-            File htmlReportDir = new File(getOutputDir(), "jacoco-report");
-            getLog().info("Writing JaCoCo report to: " + htmlReportDir);
-            report.writeHtmlReport(getTestDescription(), htmlReportDir);
-            report.writeCsvReport(getTestDescription(), htmlReportDir);
-            report.writeXmlReport(getTestDescription(), htmlReportDir);
+            File reportDir = new File(getOutputDir(), "jacoco-report");
+            getLog().info("Writing JaCoCo report to: " + reportDir);
+            reportDir.mkdirs();
+            for (ReportFormat f: formats) {
+                report.writeReport(getTestDescription(), reportDir, f);
+            }
         } catch (IOException | ReflectiveOperationException e) {
             throw new MojoExecutionException("Failed to analyze fuzzing campaign", e);
         }

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CampaignReport.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CampaignReport.java
@@ -54,7 +54,7 @@ final class CampaignReport {
             }
         }
     }
-    
+
     public void writeReport(String testDescription, File reportDir, ReportFormat f) throws IOException {
         calculator.createReport(lastExecData == null ? new byte[0] : lastExecData, testDescription, sources, f.createVisitor(reportDir));
     }

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CampaignReport.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CampaignReport.java
@@ -60,6 +60,16 @@ final class CampaignReport {
                                     reportDir);
     }
 
+    public void writeCsvReport(String testDescription, File reportDir) throws IOException {
+        calculator.createCsvReport(lastExecData == null ? new byte[0] : lastExecData, testDescription, sources,
+                                    reportDir);
+    }
+
+    public void writeXmlReport(String testDescription, File reportDir) throws IOException {
+        calculator.createXmlReport(lastExecData == null ? new byte[0] : lastExecData, testDescription, sources,
+                                    reportDir);
+    }
+
     public void record(File inputFile, byte[] execData, StackTraceElement[] trace) throws IOException {
         if (firstTimestamp == -1) {
             firstTimestamp = inputFile.lastModified();

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CampaignReport.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CampaignReport.java
@@ -54,20 +54,9 @@ final class CampaignReport {
             }
         }
     }
-
-    public void writeHtmlReport(String testDescription, File reportDir) throws IOException {
-        calculator.createHtmlReport(lastExecData == null ? new byte[0] : lastExecData, testDescription, sources,
-                                    reportDir);
-    }
-
-    public void writeCsvReport(String testDescription, File reportDir) throws IOException {
-        calculator.createCsvReport(lastExecData == null ? new byte[0] : lastExecData, testDescription, sources,
-                                    reportDir);
-    }
-
-    public void writeXmlReport(String testDescription, File reportDir) throws IOException {
-        calculator.createXmlReport(lastExecData == null ? new byte[0] : lastExecData, testDescription, sources,
-                                    reportDir);
+    
+    public void writeReport(String testDescription, File reportDir, ReportFormat f) throws IOException {
+        calculator.createReport(lastExecData == null ? new byte[0] : lastExecData, testDescription, sources, f.createVisitor(reportDir));
     }
 
     public void record(File inputFile, byte[] execData, StackTraceElement[] trace) throws IOException {

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CoverageCalculator.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CoverageCalculator.java
@@ -12,6 +12,8 @@ import org.jacoco.core.runtime.WildcardMatcher;
 import org.jacoco.core.tools.ExecFileLoader;
 import org.jacoco.report.*;
 import org.jacoco.report.html.HTMLFormatter;
+import org.jacoco.report.xml.XMLFormatter;
+import org.jacoco.report.csv.CSVFormatter;
 import org.objectweb.asm.ClassReader;
 
 import java.io.*;
@@ -78,6 +80,38 @@ class CoverageCalculator {
             analyzer.analyzeClass(idBufferMap.get(key), "");
         }
         IReportVisitor visitor = new HTMLFormatter().createVisitor(new FileMultiReportOutput(reportDir));
+        visitor.visitInfo(loader.getSessionInfoStore().getInfos(), loader.getExecutionDataStore().getContents());
+        visitor.visitBundle(builder.getBundle(testDesc), createLocator(sources));
+        visitor.visitEnd();
+    }
+
+    public void createXmlReport(byte[] execData, String testDesc, File[] sources, File reportDir)
+            throws IOException {
+        ExecFileLoader loader = new ExecFileLoader();
+        loader.load(new ByteArrayInputStream(execData));
+        CoverageBuilder builder = new CoverageBuilder();
+        Analyzer analyzer = new RecordingAnalyzer(loader.getExecutionDataStore(), builder);
+        for (Long key : idBufferMap.keySet()) {
+            analyzer.analyzeClass(idBufferMap.get(key), "");
+        }
+        IReportVisitor visitor = new XMLFormatter().createVisitor(new FileOutputStream(
+                    new File(reportDir, "jacoco.xml")));
+        visitor.visitInfo(loader.getSessionInfoStore().getInfos(), loader.getExecutionDataStore().getContents());
+        visitor.visitBundle(builder.getBundle(testDesc), createLocator(sources));
+        visitor.visitEnd();
+    }
+
+    public void createCsvReport(byte[] execData, String testDesc, File[] sources, File reportDir)
+            throws IOException {
+        ExecFileLoader loader = new ExecFileLoader();
+        loader.load(new ByteArrayInputStream(execData));
+        CoverageBuilder builder = new CoverageBuilder();
+        Analyzer analyzer = new RecordingAnalyzer(loader.getExecutionDataStore(), builder);
+        for (Long key : idBufferMap.keySet()) {
+            analyzer.analyzeClass(idBufferMap.get(key), "");
+        }
+        IReportVisitor visitor = new CSVFormatter().createVisitor(new FileOutputStream(
+                    new File(reportDir, "jacoco.csv")));
         visitor.visitInfo(loader.getSessionInfoStore().getInfos(), loader.getExecutionDataStore().getContents());
         visitor.visitBundle(builder.getBundle(testDesc), createLocator(sources));
         visitor.visitEnd();

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CoverageCalculator.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CoverageCalculator.java
@@ -11,9 +11,6 @@ import org.jacoco.core.internal.instr.InstrSupport;
 import org.jacoco.core.runtime.WildcardMatcher;
 import org.jacoco.core.tools.ExecFileLoader;
 import org.jacoco.report.*;
-import org.jacoco.report.html.HTMLFormatter;
-import org.jacoco.report.xml.XMLFormatter;
-import org.jacoco.report.csv.CSVFormatter;
 import org.objectweb.asm.ClassReader;
 
 import java.io.*;

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CoverageCalculator.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CoverageCalculator.java
@@ -70,7 +70,7 @@ class CoverageCalculator {
         return hitBranches;
     }
 
-    public void createHtmlReport(byte[] execData, String testDesc, File[] sources, File reportDir)
+    public void createReport(byte[] execData, String testDesc, File[] sources, IReportVisitor visitor)
             throws IOException {
         ExecFileLoader loader = new ExecFileLoader();
         loader.load(new ByteArrayInputStream(execData));
@@ -79,39 +79,6 @@ class CoverageCalculator {
         for (Long key : idBufferMap.keySet()) {
             analyzer.analyzeClass(idBufferMap.get(key), "");
         }
-        IReportVisitor visitor = new HTMLFormatter().createVisitor(new FileMultiReportOutput(reportDir));
-        visitor.visitInfo(loader.getSessionInfoStore().getInfos(), loader.getExecutionDataStore().getContents());
-        visitor.visitBundle(builder.getBundle(testDesc), createLocator(sources));
-        visitor.visitEnd();
-    }
-
-    public void createXmlReport(byte[] execData, String testDesc, File[] sources, File reportDir)
-            throws IOException {
-        ExecFileLoader loader = new ExecFileLoader();
-        loader.load(new ByteArrayInputStream(execData));
-        CoverageBuilder builder = new CoverageBuilder();
-        Analyzer analyzer = new RecordingAnalyzer(loader.getExecutionDataStore(), builder);
-        for (Long key : idBufferMap.keySet()) {
-            analyzer.analyzeClass(idBufferMap.get(key), "");
-        }
-        IReportVisitor visitor = new XMLFormatter().createVisitor(new FileOutputStream(
-                    new File(reportDir, "jacoco.xml")));
-        visitor.visitInfo(loader.getSessionInfoStore().getInfos(), loader.getExecutionDataStore().getContents());
-        visitor.visitBundle(builder.getBundle(testDesc), createLocator(sources));
-        visitor.visitEnd();
-    }
-
-    public void createCsvReport(byte[] execData, String testDesc, File[] sources, File reportDir)
-            throws IOException {
-        ExecFileLoader loader = new ExecFileLoader();
-        loader.load(new ByteArrayInputStream(execData));
-        CoverageBuilder builder = new CoverageBuilder();
-        Analyzer analyzer = new RecordingAnalyzer(loader.getExecutionDataStore(), builder);
-        for (Long key : idBufferMap.keySet()) {
-            analyzer.analyzeClass(idBufferMap.get(key), "");
-        }
-        IReportVisitor visitor = new CSVFormatter().createVisitor(new FileOutputStream(
-                    new File(reportDir, "jacoco.csv")));
         visitor.visitInfo(loader.getSessionInfoStore().getInfos(), loader.getExecutionDataStore().getContents());
         visitor.visitBundle(builder.getBundle(testDesc), createLocator(sources));
         visitor.visitEnd();

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/ReportFormat.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/ReportFormat.java
@@ -1,11 +1,14 @@
 package edu.neu.ccs.prl.meringue;
 
-import org.jacoco.report.*;
+import org.jacoco.report.FileMultiReportOutput;
+import org.jacoco.report.IReportVisitor;
 import org.jacoco.report.html.HTMLFormatter;
 import org.jacoco.report.xml.XMLFormatter;
 import org.jacoco.report.csv.CSVFormatter;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.FileOutputStream;
 
 public enum ReportFormat {
     HTML() {

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/ReportFormat.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/ReportFormat.java
@@ -1,0 +1,50 @@
+package edu.neu.ccs.prl.meringue;
+
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.analysis.ICoverageVisitor;
+import org.jacoco.core.data.ExecutionData;
+import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.internal.data.CRC64;
+import org.jacoco.core.internal.instr.InstrSupport;
+import org.jacoco.core.runtime.WildcardMatcher;
+import org.jacoco.core.tools.ExecFileLoader;
+import org.jacoco.report.*;
+import org.jacoco.report.html.HTMLFormatter;
+import org.jacoco.report.xml.XMLFormatter;
+import org.jacoco.report.csv.CSVFormatter;
+import org.objectweb.asm.ClassReader;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public enum ReportFormat {
+    HTML () {
+        @Override
+        IReportVisitor createVisitor (File outputDir) throws IOException {
+            return new HTMLFormatter().createVisitor(new FileMultiReportOutput(outputDir));
+        }
+    },
+    CSV () {
+        @Override
+        IReportVisitor createVisitor (File outputDir) throws IOException {
+            return new CSVFormatter().createVisitor(new FileOutputStream(
+                                                    new File(outputDir, "jacoco.csv")));
+        }
+    },
+    XML () {
+        @Override
+        IReportVisitor createVisitor (File outputDir) throws IOException {
+            return new XMLFormatter().createVisitor(new FileOutputStream(
+                                                    new File(outputDir, "jacoco.xml")));
+        }
+    };
+
+    abstract IReportVisitor createVisitor (File outputDir) throws IOException; 
+}

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/ReportFormat.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/ReportFormat.java
@@ -1,50 +1,33 @@
 package edu.neu.ccs.prl.meringue;
 
-import org.jacoco.core.analysis.Analyzer;
-import org.jacoco.core.analysis.CoverageBuilder;
-import org.jacoco.core.analysis.IClassCoverage;
-import org.jacoco.core.analysis.ICoverageVisitor;
-import org.jacoco.core.data.ExecutionData;
-import org.jacoco.core.data.ExecutionDataStore;
-import org.jacoco.core.internal.data.CRC64;
-import org.jacoco.core.internal.instr.InstrSupport;
-import org.jacoco.core.runtime.WildcardMatcher;
-import org.jacoco.core.tools.ExecFileLoader;
 import org.jacoco.report.*;
 import org.jacoco.report.html.HTMLFormatter;
 import org.jacoco.report.xml.XMLFormatter;
 import org.jacoco.report.csv.CSVFormatter;
-import org.objectweb.asm.ClassReader;
 
 import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 public enum ReportFormat {
-    HTML () {
+    HTML() {
         @Override
-        IReportVisitor createVisitor (File outputDir) throws IOException {
+        IReportVisitor createVisitor(File outputDir) throws IOException {
             return new HTMLFormatter().createVisitor(new FileMultiReportOutput(outputDir));
         }
     },
-    CSV () {
+    CSV() {
         @Override
-        IReportVisitor createVisitor (File outputDir) throws IOException {
+        IReportVisitor createVisitor(File outputDir) throws IOException {
             return new CSVFormatter().createVisitor(new FileOutputStream(
                                                     new File(outputDir, "jacoco.csv")));
         }
     },
-    XML () {
+    XML() {
         @Override
-        IReportVisitor createVisitor (File outputDir) throws IOException {
+        IReportVisitor createVisitor(File outputDir) throws IOException {
             return new XMLFormatter().createVisitor(new FileOutputStream(
                                                     new File(outputDir, "jacoco.xml")));
         }
     };
 
-    abstract IReportVisitor createVisitor (File outputDir) throws IOException; 
+    abstract IReportVisitor createVisitor(File outputDir) throws IOException;
 }


### PR DESCRIPTION
**Discription of PR**
Currently the parameterized junit4 branch only outputs JaCoCo report in the HTML format, which is difficult to work with from the command line. This PR adds a new Java option `-Dmeringue.outputFormat` that supports all three formats of JaCoCo reports, i.e., HTML, CSV, XML.

**For Code Changes:**
A new enum type `ReportFormat` is added to provide different types of `IReportVisitor`, which is used in the `writeReport` in `CampaignReport` to generate `visitor` for the `createReport` in `CoverageCalculator`.

The change has been tested on small maven projects.