### PR TITLE
Add support for recursively outputing arrays

### DIFF
--- a/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestReplayer.java
+++ b/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestReplayer.java
@@ -79,7 +79,6 @@ public final class ZestReplayer implements Replayer {
         public void observeGeneratedArgs(Object[] args) {
             if (argumentsDirectory != null) {
                 try {
-                    System.out.println(inputFile.getName());
                     observeGeneratedArgs(args, inputFile.getName(), 0);
                 } catch (IOException e) {
                     e.printStackTrace();

--- a/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestReplayer.java
+++ b/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestReplayer.java
@@ -12,7 +12,6 @@ import java.lang.reflect.Array;
 import java.util.function.Consumer;
 
 public final class ZestReplayer implements Replayer {
-    private static int maxRecurDepth = 5;
     private File argumentsDir;
     private Class<?> testClass;
     private String testMethodName;
@@ -87,7 +86,7 @@ public final class ZestReplayer implements Replayer {
         }
 
         private void observeGeneratedArgs(Object args, String fileName, int depth) throws IOException {
-            if (args.getClass().isArray() && depth < maxRecurDepth) {
+            if (args.getClass().isArray()) {
                 File file = new File(argumentsDirectory, fileName);
                 file.mkdirs();
                 for (int i = 0; i < Array.getLength(args); i++) {


### PR DESCRIPTION
**Discription of PR**
Currently the parameterized junit4 branch only outputs an address for arrays, which is not helpful for debugging. This PR instead prints the content of an array. If the content of an array is also array, this PR also adds support for outputing them recursively. This PR also changes the output formats to recursive folders, i.e., `$argFile/$indexOfArg/$indexInArray/...`

**For Code Changes:**
A new function `observeGeneratedArgs` is added so as to 'decompress' the arrays and output the elements recursively. A `maxRecurDepth` is also added to prevent stack overflow caused by too many layers of recursion.

The change has been tested on small maven projects.